### PR TITLE
Update contextual-tabs.md

### DIFF
--- a/documentation/concepts/contextual-tabs.md
+++ b/documentation/concepts/contextual-tabs.md
@@ -24,3 +24,5 @@ And associate a tab to this group:
 ```
 
 `RibbonContextualTabGroup` is not visible by default. To show or hide a contextual tab you must set the `RibbonContextualTabGroup.Visibility` property to `Visible` or `Collapsed`.
+
+Upgrade note: In Fluent.Ribbon version 3.6.1.236 the value `Hidden` was accepted. For version 6.0.x only `Collapsed` is accepted.


### PR DESCRIPTION
I've upgraded Fluent.Ribbon from 3.6.1.236 to 6.0.0.208. I had code working where the contextual tab was using "Hidden" and after the upgrade this didn't work anymore. The contextual tab was always visible. This is because only Collapsed is now supported and not anymore Hidden. Might be useful documentation for some other users.